### PR TITLE
Update mechanical-keyboard.cson

### DIFF
--- a/keymaps/mechanical-keyboard.cson
+++ b/keymaps/mechanical-keyboard.cson
@@ -7,5 +7,5 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
-'.workspace':
+'atom-workspace':
   'ctrl-alt-m k': 'mechanical-keyboard:toggle'


### PR DESCRIPTION
Fixes `Use the atom-workspace tag instead of the workspace class.` error showing up
